### PR TITLE
Remove the manager from grebase

### DIFF
--- a/config.json
+++ b/config.json
@@ -686,19 +686,6 @@
          ]
       },
       {
-         "url":"https://github.com/ebuzzing/service-manager.git",
-         "rebase":[
-            {
-               "from":"master",
-               "to":"(feat|fix|improv).*",
-               "automatic":{
-                  "rebase":false,
-                  "merge":false
-               }
-            }
-         ]
-      },
-      {
          "url":"https://github.com/ebuzzing/lib-front-shared-workflow.git",
          "rebase":[
             {


### PR DESCRIPTION
As there are too many conflicts because of the use of libs and the update of package.json
